### PR TITLE
Fix a small bug that hangs the server on old 8086 cpus

### DIFF
--- a/src/server/util_asm.s
+++ b/src/server/util_asm.s
@@ -8,10 +8,6 @@ _htons:
   push    bp
   mov     bp, sp
   mov     ax, [bp + 4]          ; Input arg (word)
-  ; r0mheat - rol ax, 8 fails on 8086
-  ; with values > 1 you must to use cl register
-  ; alternatively we can use xchg
-  ;rol     ax, 8                 ; https://stackoverflow.com/a/47021804
   xchg    al, ah
   pop     bp
   ret                           ; Result in AX.

--- a/src/server/util_asm.s
+++ b/src/server/util_asm.s
@@ -8,7 +8,11 @@ _htons:
   push    bp
   mov     bp, sp
   mov     ax, [bp + 4]          ; Input arg (word)
-  rol     ax, 8                 ; https://stackoverflow.com/a/47021804
+  ; r0mheat - rol ax, 8 fails on 8086
+  ; with values > 1 you must to use cl register
+  ; alternatively we can use xchg
+  ;rol     ax, 8                 ; https://stackoverflow.com/a/47021804
+  xchg    al, ah
   pop     bp
   ret                           ; Result in AX.
 


### PR DESCRIPTION
Real 8086 CPUs require you to use the cl register when the value to rotate is greater than one, e.g. mov cl,8 then rol ax,cl. I didn't know that, so it was fun debugging on my old 8086 and learning something new. 