### PR TITLE
Show the cursor on the client screen.

### DIFF
--- a/src/client/curses.c
+++ b/src/client/curses.c
@@ -200,6 +200,13 @@ void update_session_window(struct RemoteHost *rh, uint16_t vga_offset,
     }
     wattroff(g_session_window, COLOR_PAIR(g_ncurses_colors[0x4f]));
   }
+  
+  // r0mheat - show a "cursor" at your current position
+  if (OK == wmove(g_session_window, rh->status.cursor_row, rh->status.cursor_col)) {
+    wattron(g_session_window, COLOR_PAIR(MY_COLOR_HEADER));
+    waddch(g_session_window, ' ' | A_REVERSE);
+    wattroff(g_session_window, COLOR_PAIR(MY_COLOR_HEADER));
+  }
 }
 
 void init_ncurses() {

--- a/src/client/curses.c
+++ b/src/client/curses.c
@@ -200,8 +200,8 @@ void update_session_window(struct RemoteHost *rh, uint16_t vga_offset,
     }
     wattroff(g_session_window, COLOR_PAIR(g_ncurses_colors[0x4f]));
   }
-  
-  // r0mheat - show a "cursor" at your current position
+
+  // show a "cursor" at your current position
   if (OK == wmove(g_session_window, rh->status.cursor_row, rh->status.cursor_col)) {
     wattron(g_session_window, COLOR_PAIR(MY_COLOR_HEADER));
     waddch(g_session_window, ' ' | A_REVERSE);

--- a/src/client/main.c
+++ b/src/client/main.c
@@ -173,6 +173,11 @@ void process_incoming_vga_text(const uint8_t *buf, size_t received) {
 
   rh->text_rows = vga->text_rows;
   rh->text_cols = vga->text_cols;
+
+  // we already have a place to store the cursor position
+  rh->status.cursor_row = vga->cursor_row;
+  rh->status.cursor_col = vga->cursor_col;
+
   update_session_window(rh, offset, count);
 }
 

--- a/src/common/protocol.h
+++ b/src/common/protocol.h
@@ -123,6 +123,8 @@ struct StatusResponse {
 struct VgaText {
   uint8_t text_rows; // Current height of the screen
   uint8_t text_cols; // Current width of the screen
+  uint8_t cursor_row; // Current row of the cursor
+  uint8_t cursor_col; // Current column of the cursor
   uint16_t offset;   // Byte offset from $b800:0
   uint16_t count;    // Count of BYTES of data in packet
 };

--- a/src/server/session.c
+++ b/src/server/session.c
@@ -172,6 +172,8 @@ void session_mgr_update_all() {
 
   resp->text_rows = vga.text_rows;
   resp->text_cols = vga.text_cols;
+  resp->cursor_row = vga.cursor_row;
+  resp->cursor_col = vga.cursor_col;
   resp->offset = htons(offset);
   resp->count = htons(word_count * VGA_WORD);
 


### PR DESCRIPTION
I've  embedded the cursor position in VgaText. On the server, the state is always checked before sending the packet so we have already taken the current position. It takes only 16 bits on the packet, which is not much and made editing amazing.  
![rmt_dos_cursor](https://github.com/user-attachments/assets/69b2a696-75d3-40c8-aa7e-12d4c9a51d44)
