### PR TITLE
Fix EGA detection

### DIFF
--- a/src/lib16/vga.s
+++ b/src/lib16/vga.s
@@ -202,8 +202,8 @@ vga_read_state_no_vga:
   mov     ax, #$1200
   mov     bx, #$0010
   int     $10
-  cmp     bl, #$10
-  je      vga_read_state_have_vga_or_ega     ; EGA detected
+  cmp     bl, #$10  
+  jne     vga_read_state_have_vga_or_ega     ; EGA detected
 
 vga_read_state_done:
   pop     es

--- a/src/lib16/vga.s
+++ b/src/lib16/vga.s
@@ -202,7 +202,7 @@ vga_read_state_no_vga:
   mov     ax, #$1200
   mov     bx, #$0010
   int     $10
-  cmp     bl, #$10  
+  cmp     bl, #$10
   jne     vga_read_state_have_vga_or_ega     ; EGA detected
 
 vga_read_state_done:


### PR DESCRIPTION
Fix EGA detection, if bl remains unchanged it means the EGA is not present. Function not implemented.
Now EGA has detected well and got the correct rows, CGA ends up defaulting to 25.