### PR TITLE
Agnostic video subsystem & checksum screen updates

### DIFF
--- a/src/client/curses.c
+++ b/src/client/curses.c
@@ -158,14 +158,14 @@ void update_hud(struct RemoteHost *rh) {
   mvwprintw(rh->window, ++y, 0, "<ALT-ESC> to Exit");
 }
 
-void update_session_window(struct RemoteHost *rh, uint16_t vga_offset,
+void update_session_window(struct RemoteHost *rh, uint16_t video_offset,
                            uint16_t byte_count) {
 
-  for (uint16_t i = vga_offset; i < (vga_offset + byte_count); i += 2) {
+  for (uint16_t i = video_offset; i < (video_offset + byte_count); i += 2) {
     const uint16_t y = (i >> 1) / rh->text_cols;
     const uint16_t x = (i >> 1) % rh->text_cols;
-    const uint8_t ch = rh->vga_text_buffer[i];
-    const uint8_t attr = rh->vga_text_buffer[i + 1];
+    const uint8_t ch = rh->video_text_buffer[i];
+    const uint8_t attr = rh->video_text_buffer[i + 1];
 
     wattron(g_session_window, COLOR_PAIR(g_ncurses_colors[attr]));
     //  wattron(g_session_window, PAIR_NUMBER(attr));

--- a/src/client/hostlist.c
+++ b/src/client/hostlist.c
@@ -99,7 +99,7 @@ void hostlist_register(const uint8_t *packet, size_t length) {
   if (ntohs(ph->pkt_type) == V1_STATUS_RESP) {
     const struct StatusResponse *s = (const struct StatusResponse *)(ph + 1);
 
-    rh->status.vga_mode = s->vga_mode;
+    rh->status.video_mode = s->video_mode;
     rh->status.active_page = s->active_page;
     rh->status.text_rows = s->text_rows;
     rh->status.text_cols = s->text_cols;

--- a/src/client/hostlist.h
+++ b/src/client/hostlist.h
@@ -43,7 +43,7 @@ struct RemoteHost {
 
   // Raw VGA text buffer, as sent from client in V1_VGA_TEXT packets.
   // VGA text buffer is from $000b8000 to $000bffff (32KiB).
-  uint8_t vga_text_buffer[32768];
+  uint8_t video_text_buffer[32768];
 };
 
 extern void hostlist_create();

--- a/src/client/main.c
+++ b/src/client/main.c
@@ -112,7 +112,7 @@ void update_probing_window(const struct RawSocket *rs) {
 
       mvwprintw(w, y, 1, "%2d  %s   %2d  %3d %3d  %s", r->index,
                 fmt_mac_addr(mac_tmp, sizeof(mac_tmp), r->if_addr),
-                r->status.vga_mode, r->status.text_cols, r->status.text_rows,
+                r->status.video_mode, r->status.text_cols, r->status.text_rows,
                 stale);
       ++y;
     }
@@ -150,11 +150,11 @@ void debug_show_incoming_packet(const uint8_t *buf, size_t received) {
   }
 }
 
-void process_incoming_vga_text(const uint8_t *buf, size_t received) {
+void process_incoming_video_text(const uint8_t *buf, size_t received) {
   const struct ether_header *eh = (const struct ether_header *)buf;
   const struct ProtocolHeader *ph = (const struct ProtocolHeader *)(eh + 1);
-  const struct VgaText *vga = (const struct VgaText *)(ph + 1);
-  const uint8_t *data = (const uint8_t *)(vga + 1);
+  const struct VideoText *video = (const struct VideoText *)(ph + 1);
+  const uint8_t *data = (const uint8_t *)(video + 1);
 
   struct RemoteHost *rh = hostlist_find_by_mac(eh->ether_shost);
   if (!rh) {
@@ -163,20 +163,20 @@ void process_incoming_vga_text(const uint8_t *buf, size_t received) {
 
   gettimeofday(&(rh->tv_last_resp), NULL);
 
-  const uint16_t offset = ntohs(vga->offset);
-  const uint16_t count = ntohs(vga->count);
-  if (count + offset > sizeof(rh->vga_text_buffer)) {
+  const uint16_t offset = ntohs(video->offset);
+  const uint16_t count = ntohs(video->count);
+  if (count + offset > sizeof(rh->video_text_buffer)) {
     return;
   }
 
-  memcpy(rh->vga_text_buffer + offset, data, count);
+  memcpy(rh->video_text_buffer + offset, data, count);
 
-  rh->text_rows = vga->text_rows;
-  rh->text_cols = vga->text_cols;
+  rh->text_rows = video->text_rows;
+  rh->text_cols = video->text_cols;
 
   // we already have a place to store the cursor position
-  rh->status.cursor_row = vga->cursor_row;
-  rh->status.cursor_col = vga->cursor_col;
+  rh->status.cursor_row = video->cursor_row;
+  rh->status.cursor_col = video->cursor_col;
 
   update_session_window(rh, offset, count);
 }
@@ -219,7 +219,7 @@ void process_socket_io(struct RawSocket *rs) {
       hostlist_register(buf, received);
       break;
     case V1_VGA_TEXT:
-      process_incoming_vga_text(buf, received);
+      process_incoming_video_text(buf, received);
       break;
   }
 }
@@ -236,7 +236,7 @@ void start_remote_control(struct RemoteHost *rh) {
 void process_stdin_menu_mode() {
   int c = getch();
 
-  if (c == EXIT_WCH_CODE) {
+  if (c == EXIT_WCH_CODE || c == KEY_F(12) || c == 27) {
     g_running = 0;
     return;
   }

--- a/src/common/protocol.h
+++ b/src/common/protocol.h
@@ -110,7 +110,7 @@ struct ProtocolHeader {
 
 // V1_STATUS_RESP: Server -> Client
 struct StatusResponse {
-  uint8_t vga_mode;
+  uint8_t video_mode;
   uint8_t active_page;
   uint8_t text_rows;
   uint8_t text_cols;
@@ -120,7 +120,7 @@ struct StatusResponse {
 
 // V1_VGA_TEXT: Server -> Client
 // Followed by raw data, to end of packet.
-struct VgaText {
+struct VideoText {
   uint8_t text_rows; // Current height of the screen
   uint8_t text_cols; // Current width of the screen
   uint8_t cursor_row; // Current row of the cursor

--- a/src/lib16/video.h
+++ b/src/lib16/video.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 Dennis Jenkins <dennis.jenkins.75@gmail.com>
+ * Copyright 2025 <romheat@gmail.com>
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#ifndef __RMTDOS_LIB16_VIDEO_H
+#define __RMTDOS_LIB16_VIDEO_H
+
+#include "lib16/types.h"
+
+#define VIDEO_ROWS 25
+#define VIDEO_COLS 80
+#define VIDEO_WORD 2
+#define VIDEO_SIZE (VIDEO_ROWS * VIDEO_COLS * VIDEO_WORD)
+
+// Initialize video functions
+// internally store the segment base address
+// MUST be called before any other video functions
+extern uint16_t video_init();
+
+// Store the segment base address
+extern uint16_t video_address;
+
+// Returns video segment base address.
+extern uint16_t video_get_segment();
+
+// Copy 'words' count of WORDS (16-bit ints) from Video Text Mode
+// frame buffer, starting at offset from [$b800:0000] or [$b000:0000]
+// into dest.
+extern void video_copy_from_frame_buffer(void *dest, uint16_t offset,
+                                         uint16_t words);
+
+// Same function that is on vga.s via int 0x10, ah=0x0f
+// puts he cursor in the specified position
+extern void video_gotoxy(int x, int y);
+
+// Write a string to the screen at (x, y) with attribute attr.
+extern void video_write_str(int x, int y, uint8_t attr, const char *str);
+
+// Write a string to the screen at (x, y) with attribute attr.
+// The string is formatted using printf-style formatting.
+extern int video_printf(int x, int y, uint8_t attr, const char *fmt, ...);
+
+// Erase all screen text from "y1 <= y < y2".
+extern void video_clear_rows(int y1, int y2);
+
+struct VideoState {
+  uint8_t video_mode;  // int $10, ah=$0f, al value
+  uint8_t active_page; // int $10, ah=$0f, bh value
+  uint8_t text_rows;   // (no direct query for this)
+  uint8_t text_cols;   // int $10, ah=$0f, ah value
+  uint8_t cursor_row;  // int $10, ah=$03, dh value
+  uint8_t cursor_col;  // int $10, ah=$03, dl value
+};
+
+// Read the current video state into the provided struct.
+extern void video_read_state(struct VideoState *state);
+
+// Checksum the video frame buffer.
+// This is used to detect changes in the video memory.
+extern uint16_t video_checksum_frame_buffer(uint16_t offset, uint16_t words);
+
+#endif // __RMTDOS_LIB16_VIDEO_H

--- a/src/lib16/video.s
+++ b/src/lib16/video.s
@@ -1,0 +1,339 @@
+;  SPDX-FileCopyrightText: 2022 Dennis Jenkins <dennis.jenkins.75@gmail.com>
+;  SPDX-FileCopyrightText: 2025 r0mheat <romheat@gmail.com>
+;  SPDX-License-Identifier: GPL-2.0-or-later
+
+; Will store the detected video segment (0xB800 or 0xB000)
+; here .data = .text 
+.data
+
+SEG_COLOR = $B800
+SEG_MDA   = $B000
+
+.global _video_address
+_video_address:
+  dw      0                   
+
+; uint16_t detect_video_segment(void);
+; Returns 0xB800 for VGA/CGA or 0xB000 for MDA/Hercules
+.text
+.global _video_get_segment
+_video_get_segment:
+  push     bp
+  mov      bp, sp
+
+  mov      ax, #$0040               ; BIOS data area
+  mov      es, ax
+
+  seg      es
+  mov      al, [$10]                ; Active display mode
+  and      al, #$30                 ; Check bits 4-5 for adapter type
+  cmp      al, #$30                 ; MDA mode?
+  jne      not_mda
+
+  mov      ax, #$b000               ; Return MDA segment
+  jmp      vgs_done
+
+not_mda:
+  mov      ax, #$b800               ; Return VGA/CGA segment
+
+vgs_done:
+  pop      bp
+  ret
+
+; void video_init(void);
+; Detects and stores the video segment for later use. Must be called first.
+.text
+.global _video_init
+_video_init:
+    push    bp
+    mov     bp, sp
+    call    _video_get_segment      ; Detect segment (result in AX)
+    mov     [_video_address], ax    ; Store it globally
+    pop     bp
+    ret
+
+; void video_write_str(int x, int y, uint8_t attr, const char *str)
+; Writes string using the globally stored video segment.
+.text
+.global _video_write_str
+_video_write_str:
+  push     bp
+  mov      bp, sp
+  push     es                       ; Save ES
+
+  ;  Get video segment from global variable 
+  mov      ax, [_video_address]
+  mov      es, ax                   ; ES = Video Segment
+
+  ;  Calculate screen offset 
+  push     ds                       ; Need DS temporarily for BIOS data
+  mov      ax, #$0040               ; BIOS data area
+  mov      ds, ax   
+  mov      bx, [$4a]                ; Number of screen columns (width)
+  pop      ds                       ; Restore original DS
+
+  mov      ax, [bp + 6]             ; AX = y  (Stack: [bp+2]=ret, [bp+4]=x, [bp+6]=y, [bp+8]=attr, [bp+10]=str)
+  mul      bl                       ; AX = y * width
+  mov      bx, [bp + 4]             ; BX = x
+  add      ax, bx                   ; AX = (y * width) + x
+  add      ax, ax                   ; AX = 2 * ((y * width) + x) ; byte offset
+  mov      di, ax                   ; ES:DI points into text buffer start
+
+  ; Handle page offset if needed (for VGA only)
+  cmp      word ptr [_video_address], #$b800
+  jne      skip_page_offset         ; Skip for MDA
+
+  push     ds                       ; Need DS again for BIOS data
+  mov      ax, #$0040
+  mov      ds, ax
+  mov      cx, [$4e]                ; Offset of current video page (word offset)
+  pop      ds                       ; Restore original DS
+  add      di, cx                   ; Adjust DI for alternate video pages (byte offset)
+
+skip_page_offset:
+  ;  Write the string 
+  mov      ah, [bp + 8]             ; AH = attr
+  mov      si, [bp + 10]            ; DS:SI = str (Assume near pointer)
+
+video_write_str_loop:
+  lodsb                             ; AL = [DS:SI], SI++ (Get char)
+  or       al, al
+  jz       video_write_str_done
+
+  seg      es
+  stosw                             ; Store AX (attr, char) to [ES:DI], DI += 2
+
+  jmp      video_write_str_loop
+
+video_write_str_done:
+  pop      es                       ; Restore original ES
+  pop      bp
+  ret                               ; Return (8 bytes of params popped by caller if cdecl)
+
+
+; void video_gotoxy(int x, int y);
+; Same vga_gotoxy using interrupt
+.text
+.global _video_gotoxy
+_video_gotoxy:
+#if __FIRST_ARG_IN_AX__
+  mov      bx, sp
+  mov      dl, al
+  mov      ax, [bx+2]
+  mov      dh, al
+#else
+  mov      bx, sp
+  mov      ax, [bx+4]               ; y
+  mov      dh, al
+  mov      ax, [bx+2]               ; x
+  mov      dl, al
+#endif
+  mov      ah, #$02                 ; Set cursor position BIOS call
+  mov      bh, #0                   ; Assume page 0 (can be read from VgaState if needed)
+  int      $10
+  ret
+
+
+; void video_read_state(struct VgaState *state);
+; Read video info handling for MDA, CGA, EGA, and VGA.
+; struct VgaState {
+;   unsigned char video_mode;   // offset 0
+;   unsigned char active_page;  // offset 1
+;   unsigned char text_rows;    // offset 2
+;   unsigned char text_cols;    // offset 3
+;   unsigned char cursor_row;   // offset 4
+;   unsigned char cursor_col;   // offset 5
+; };
+
+.text
+.global _video_read_state
+_video_read_state:
+  push    bp
+  mov     bp, sp
+  push    es
+  push    di
+  mov     di, [bp + 4]              ; di = state
+
+  ; Get current video mode.
+  mov     ah, #$0f                  ; "get video mode"
+  int     $10
+  mov     [di], al                  ; state->video_mode
+  mov     [di + 1], bh              ; state->active_page
+  mov     [di + 2], #25             ; state->text_rows (assume 25 for now)
+  mov     [di + 3], ah              ; state->text_cols
+
+  ; Get cursor info.
+  mov     ah, #$03                  ; "get cursor info"
+                                    ; BH = page number (already set)
+  int     $10
+  mov     [di + 4], dh              ; state->cursor_row
+  mov     [di + 5], dl              ; state->cursor_col
+
+  ; Determine if we have an EGA or VGA video card.
+  ; http://www.ctyme.com/intr/rb-0219.htm
+  mov     ax, #$1a00                ; Canonical VGA adapter check
+  int     $10
+  cmp     al, #$1a
+  jne     video_rs_no_vga           ; No VGA, check for EGA
+  cmp     bl, #6
+  jb      video_rs_no_vga           ; No VGA, check for EGA
+
+video_rs_ega_vga:
+  mov     ax, #$0040                ; BIOS data area.
+  mov     es, ax
+  seg     es
+  mov     al, [$84]                 ; Screen rows (minus one).
+  inc     al
+  mov     [di + 2], al              ; state->text_rows
+  jmp     video_rs_done
+
+video_rs_no_vga:
+  ; Test for EGA
+  mov     ax, #$1200
+  mov     bx, #$0010
+  int     $10
+  cmp     bl, #$10
+  jne     video_rs_ega_vga          ; EGA detected
+
+video_rs_done:
+  pop     es
+  pop     di
+  pop     bp
+  ret
+
+; void video_clear_rows(int y1, int y2)
+; Clears rows using the globally stored video segment.
+.text
+.global _video_clear_rows
+_video_clear_rows:
+  push     bp
+  mov      bp, sp
+  push     es
+  push     di
+
+  ;  Get video segment 
+  mov      ax, [_video_address]
+  mov      es, ax                   ; ES = Video Segment
+
+  ;  Calculate count and starting offset 
+  mov      ax, [bp + 6]             ; AX = y2 
+  mov      dx, [bp + 4]             ; DX = y1
+  inc      ax                       ;
+  sub      ax, dx                   ; AX = (y2 - y1 + 1) = row count
+  mov      dl, #80                  ; Assume 80-column text mode width
+  mul      dl                       ; AX = row count * 80 columns
+  mov      cx, ax                   ; CX = word count (chars+attrs)
+
+  mov      ax, [bp + 4]             ; AX = y1 (starting row)
+  mov      dl, #160                 ; 80 columns * 2 bytes/char = 160 bytes per row
+  mul      dl                       ; AX = starting byte offset
+  mov      di, ax                   ; ES:DI = buffer pos to start clearing
+
+  ;  Determine fill character/attribute 
+  cmp      word ptr [_video_address], #$b800
+  jne      mda_attribute
+
+  mov      ax, #$0720               ; VGA "space on light grey" 
+  jmp      fill_screen
+
+mda_attribute:
+  mov      ax, #$0720               ; MDA "space"
+
+fill_screen:
+  
+  cld                               ; Ensure direction is forward
+  rep 
+  stosw                             ; Store AX (char+attr) CX times to ES:DI, incrementing DI
+
+  pop      di                   
+  pop      es                   
+  pop      bp
+  ret                               
+
+; void video_copy_from_frame_buffer(
+;  void *dest,        Destination buffer (near pointer in DS)
+;  uint16_t offset,   Source offset in video segment
+;  uint16_t words     Number of words to copy
+; );
+; Copies data FROM video memory TO program memory using global segment.
+.text
+.global _video_copy_from_frame_buffer
+_video_copy_from_frame_buffer:
+  push     bp
+  mov      bp, sp
+  push     ds           
+  push     es           
+  push     si          
+  push     di        
+
+  ; [bp + 4] = dest 
+  ; [bp + 6] = offset
+  ; [bp + 8] = words
+  
+  mov      ax, ds 
+  mov      es, ax  
+  mov      di, [bp + 4]             ; dest into di
+
+  mov      ax, [_video_address]      
+  mov      ds, ax                   
+  mov      si, [bp + 6]             ; offset into si
+
+  ;  Perform Copy Operation 
+  cld                               ; flag is forward for movsw
+  mov      cx, [bp + 8]             ; words to copy
+  rep 
+  movsw                             
+
+  ; restore & return
+  pop      di
+  pop      si
+  pop      es
+  pop      ds           
+  pop      bp
+  ret                  
+
+; uint16_t video_checksum_frame_buffer(
+;  uint16_t offset,      Offset from frame buffer start
+;  uint16_t words        Number of words to checksum
+; );
+; Calculate screen checksum 
+
+.text
+.global _video_checksum_frame_buffer
+_video_checksum_frame_buffer:
+  push     bp
+  mov      bp, sp
+  push     ds           
+  push     si           
+  push     bx           
+  push     dx           
+
+  ; [bp + 0] = previous frame's BP
+  ; [bp + 2] = return address
+  ; [bp + 4] = offset
+  ; [bp + 6] = words
+  
+  mov      ax, [_video_address] 
+  mov      ds, ax
+  mov      si, [bp + 4]             ; offset into si
+
+  mov      cx, [bp + 6]             ; words (always 2)
+  xor      dx, dx                   ; init 0
+
+checksum_loop:
+  seg      ds                       
+  mov      bx, [si]                 ; load ds:si
+  xchg     bh, bl                   ; swap bytes for checksum
+  add      dx, bx                   ; add
+  rol      dx, #1                   ; rotate checksum left by 1 bit 
+  add      si, #2                   ; sum
+  loop     checksum_loop            
+
+  mov      ax, dx                   ; return checksum  
+
+  pop      dx           
+  pop      bx
+  pop      si
+  pop      ds
+  pop      bp
+  ret                 

--- a/src/lib16/video_prnt.c
+++ b/src/lib16/video_prnt.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 Dennis Jenkins <dennis.jenkins.75@gmail.com>
+ * Copyright 2025 r0mheat <romheat@gmail.com>
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include <stdarg.h>
+#include <stdio.h>
+
+#include "lib16/video.h"
+
+// 1 line of 80-col text, plus "\0", rounded up.
+#define BUF_LEN 82
+
+int video_printf(int x, int y, uint8_t attr, const char *fmt, ...) {
+  va_list ap;
+  int r;
+  char tmp[BUF_LEN];
+
+  va_start(ap, fmt);
+  r = vsprintf(tmp, fmt, ap);
+  va_end(ap);
+
+  video_write_str(x, y, attr, tmp);
+
+  return r;
+}

--- a/src/server/debug.c
+++ b/src/server/debug.c
@@ -6,7 +6,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#include "lib16/vga.h"
+#include "lib16/video.h"
 #include "server/debug.h"
 
 void hex_dump(FILE *fp, const void *buffer, size_t bytes) {
@@ -35,5 +35,5 @@ void hex_dump(FILE *fp, const void *buffer, size_t bytes) {
 }
 
 void log_checkpoint(const char *file, int line) {
-  vga_printf(0, 0, 0x1f, "CP: %s:%d     ", file, line);
+  video_printf(0, 0, 0x1f, "CP: %s:%d     ", file, line);
 }

--- a/src/server/globals.c
+++ b/src/server/globals.c
@@ -7,7 +7,8 @@
 
 uint32_t session_lifetime_bios_ticks = 182; // ~10s
 
-uint16_t vga_next_row = 0;
+//uint16_t video_segment = 0;
+uint16_t video_next_row = 0;
 
 uint16_t g_ethertype = ETHERTYPE_RMTDOS;
 

--- a/src/server/globals.h
+++ b/src/server/globals.h
@@ -18,8 +18,10 @@
 */
 extern uint32_t session_lifetime_bios_ticks;
 
-// Next row of VGA text to send in the next V1_VGA_TEXT packet.
-extern uint16_t vga_next_row;
+// Checksum of the video memory.  Used to detect changes in the video
+extern uint16_t video_checksum;
+// The next row of the video memory to write to.  This is used to
+extern uint16_t video_next_row;
 
 // Our custom 'EtherType' that we use.
 extern uint16_t g_ethertype;
@@ -28,7 +30,7 @@ extern uint16_t g_ethertype;
 extern uint8_t g_send_buffer[ETH_FRAME_LEN];
 
 #if DEBUG
-// Should we overlay some debugging data onto the VGA text screen.
+// Should we overlay some debugging data onto the text screen.
 extern int g_show_debug_overlay;
 #endif
 

--- a/src/server/main.c
+++ b/src/server/main.c
@@ -13,7 +13,7 @@
 #include <stdlib.h>
 
 #include "lib16/hex2int.h"
-#include "lib16/vga.h"
+#include "lib16/video.h"
 #include "lib16/x86.h"
 #include "server/bufmgr.h"
 #include "server/config.h"
@@ -101,7 +101,7 @@ void print_usage(const char *prog) {
   printf("Usage: %s [-b #] [-d] [-e type] [-i irq#] [-u]\n", prog);
   printf("  -b  Count of Ethernet receive buffers (decimal).\n");
 #if DEBUG
-  printf("  -d  Show debug overlay on VGA text screen.\n");
+  printf("  -d  Show debug overlay.\n");
 #endif
   printf("  -e  Override EtherType (4 hex digits).\n");
   printf("  -i  IRQ for packet driver.  Omit to auto-probe. (decimal)\n");
@@ -119,6 +119,7 @@ int main(int argc, char *argv[]) {
   struct CpuRegs regs;
   char tmp[32];
   void *keep_ptr = NULL;
+  struct VideoState video_state;
 
   while (-1 != (opt = getopt(argv, argv, "b:de:hi:u"))) {
     switch (opt) {
@@ -167,6 +168,12 @@ int main(int argc, char *argv[]) {
   } else if (buffers > MAX_BUFFERS) {
     buffers = MAX_BUFFERS;
   }
+
+  video_init();
+  
+  // video_read_state(&video_state);
+  // printf("Video State: %02x %02x %02x %02x\n", video_state.video_mode,
+  //        video_state.active_page, video_state.text_rows, video_state.text_cols);
 
   // Check to see if a previous incarnation is already installed / "resident".
   x86_reset_regs(&regs);

--- a/src/server/protocol.c
+++ b/src/server/protocol.c
@@ -8,8 +8,9 @@
 #include <string.h>
 
 #include "lib16/types.h"
-#include "lib16/vga.h"
+#include "lib16/video.h"
 #include "lib16/x86.h"
+
 #include "server/bufmgr.h"
 #include "server/debug.h"
 #include "server/globals.h"
@@ -28,8 +29,8 @@ static void display_packet(const struct Buffer *buffer) {
   char tmp[MAC_ADDR_FMT_LEN];
   const uint16_t max_display_bytes = (2 * 16);
 
-  vga_gotoxy(0, 36);
-  vga_clear_rows(36, 50);
+  video_gotoxy(0, 36);
+  video_clear_rows(36, 50);
 
   printf("Raw Size:    %4d\n", buffer->bytes);
   printf("Dest:        %s\n", fmt_mac_addr(tmp, eh->dest_mac_addr));
@@ -98,20 +99,20 @@ void handle_status_req(const struct Buffer *buffer) {
   struct EthernetHeader *out_eh = (struct EthernetHeader *)(g_send_buffer);
   struct ProtocolHeader *out_ph = (struct ProtocolHeader *)(out_eh + 1);
   struct StatusResponse *resp = (struct StatusResponse *)(out_ph + 1);
-  struct VgaState vga;
+  struct VideoState video;
 
-  vga_read_state(&vga);
+  video_read_state(&video);
 
   prep_for_reply(buffer);
   out_ph->pkt_type = htons(V1_STATUS_RESP);
   out_ph->payload_len = htons(sizeof(*resp));
 
-  resp->vga_mode = vga.video_mode;
-  resp->active_page = vga.active_page;
-  resp->text_rows = vga.text_rows;
-  resp->text_cols = vga.text_cols;
-  resp->cursor_row = vga.cursor_row;
-  resp->cursor_col = vga.cursor_col;
+  resp->video_mode = video.video_mode;
+  resp->active_page = video.active_page;
+  resp->text_rows = video.text_rows;
+  resp->text_cols = video.text_cols;
+  resp->cursor_row = video.cursor_row;
+  resp->cursor_col = video.cursor_col;
 
 #define V1_STATUS_RESP_LEN (COMBINED_HEADER_LEN + sizeof(*resp))
 
@@ -134,7 +135,7 @@ void handle_inject_keystroke(const struct Buffer *buffer) {
 
   for (; key_count; ++in_keys, --key_count) {
 #if DEBUG
-    vga_printf(0, 0, 15, "key: %02x %02x %02x ", in_keys->bios_scan_code,
+    video_printf(0, 0, 15, "key: %02x %02x %02x ", in_keys->bios_scan_code,
                in_keys->ascii_value, in_keys->flags_17);
 #endif
 

--- a/src/server/resident.c
+++ b/src/server/resident.c
@@ -9,8 +9,8 @@
 #include <dos.h>
 #endif
 
-#include "lib16/vga.h"
 #include "lib16/x86.h"
+#include "lib16/video.h"
 #include "server/config.h"
 #include "server/globals.h"
 #include "server/int08.h"
@@ -81,14 +81,14 @@ int resident_do_uninstall() {
 
 #if DEBUG
 void isr_show_debug_stats() {
-  vga_printf(64, 0, 15, "int 08: %8lu", int08_ticks);
+  video_printf(64, 0, 15, "int 08: %8lu", int08_ticks);
 #if HAS_INT28
-  vga_printf(64, 1, 15, "int 28: %8lu", int28_ticks);
+  video_printf(64, 1, 15, "int 28: %8lu", int28_ticks);
 #endif
-  vga_printf(64, 2, 15, "int 2f: %8lu", int2f_ticks);
-  vga_printf(64, 3, 15, "Bios:  %9lu", x86_read_bios_tick_clock());
-  vga_printf(64, 4, 15, "Recv:  %9lu", g_pktdrv_stats.packets_recv);
-  vga_printf(64, 5, 15, "Drop:  %9lu", g_pktdrv_stats.packets_dropped);
+  video_printf(64, 2, 15, "int 2f: %8lu", int2f_ticks);
+  video_printf(64, 3, 15, "Bios:  %9lu", x86_read_bios_tick_clock());
+  video_printf(64, 4, 15, "Recv:  %9lu", g_pktdrv_stats.packets_recv);
+  video_printf(64, 5, 15, "Drop:  %9lu", g_pktdrv_stats.packets_dropped);
 }
 #endif
 

--- a/src/server/session.c
+++ b/src/server/session.c
@@ -129,7 +129,7 @@ void session_mgr_update_all() {
 #endif
 
   // Need to wrap around and start over, but also the video mode could have
-  // changed since our last cycle, and the screne is now SHORTER than it used
+  // changed since our last cycle, and the screen is now SHORTER than it used
   // to be.
   if (video_next_row >= video.text_rows) {
     video_next_row = 0;

--- a/src/server/session.c
+++ b/src/server/session.c
@@ -6,7 +6,7 @@
 #include <stddef.h>
 #include <string.h>
 
-#include "lib16/vga.h"
+#include "lib16/video.h"
 #include "lib16/x86.h"
 #include "server/bufmgr.h"
 #include "server/debug.h"
@@ -21,6 +21,8 @@ static struct Session *g_session_eof = g_sessions + MAX_SESSIONS;
 
 static uint8_t null_if_addr[ETH_ALEN] = {0, 0, 0, 0, 0, 0};
 
+static uint16_t video_chksum = 0;
+
 void session_mgr_init() { memset(&g_sessions, 0, sizeof(g_sessions)); }
 
 #if DEBUG
@@ -31,7 +33,7 @@ void session_mgr_debug() {
 
   for (i = 0, s = g_sessions; i < MAX_SESSIONS; ++s, ++i) {
     char tmp[MAC_ADDR_FMT_LEN];
-    vga_printf(4, i + 3, 2, "%d  %08lx  %s  %9ld", i, s->session_id,
+    video_printf(4, i + 3, 2, "%d  %08lx  %s  %9ld", i, s->session_id,
                fmt_mac_addr(tmp, s->mac_addr), now - s->t_last_recv);
   }
 }
@@ -70,6 +72,7 @@ struct Session *session_mgr_start(const struct Buffer *buffer) {
   }
 
   s->t_last_recv = x86_read_bios_tick_clock();
+  s->video_chksum = 0;
 
   return s;
 }
@@ -78,20 +81,22 @@ void session_mgr_reclaim(struct Session *s) { memset(s, 0, sizeof(*s)); }
 
 void session_mgr_update(struct Session *s) {}
 
+
 void session_mgr_update_all() {
   struct EthernetHeader *out_eh = (struct EthernetHeader *)(g_send_buffer);
   struct ProtocolHeader *out_ph = (struct ProtocolHeader *)(out_eh + 1);
-  struct VgaText *resp = (struct VgaText *)(out_ph + 1);
-  uint8_t *vga_data = (uint8_t *)(resp + 1);
+  struct VideoText *resp = (struct VideoText *)(out_ph + 1);
+  uint8_t *video_data = (uint8_t *)(resp + 1);
   struct Session *s;
-  struct VgaState vga;
+  struct VideoState video;
   uint32_t now = x86_read_bios_tick_clock();
   int rows;
   int active_sessions = 0;
   uint16_t payload_len;
   uint16_t offset = 0;
   uint16_t word_count = 0;
-
+  uint16_t video_curr_chksum = 0;
+  
   // Prune any stale sessions.
   for (s = g_sessions; s < g_session_eof; ++s) {
     // Is session in use?
@@ -110,55 +115,71 @@ void session_mgr_update_all() {
   }
 
   if (!active_sessions) {
-    vga_next_row = 0;
+    video_next_row = 0;
     return;
   }
 
-  // Determine next chunk of VGA data to send to all clients.
+  // Determine next chunk of Video data to send to all clients.
   // Compute how many rows we can fit into a packet.
-  vga_read_state(&vga);
+  video_read_state(&video);
+
 #if DEBUG
-  vga_printf(40, 20, 15, "vga: %d %d %d %d    ;", vga.video_mode,
-             vga.active_page, vga.text_rows, vga.text_cols);
+  video_printf(40, 20, 15, "video: %d %d %d %d    ;", video.video_mode,
+             video.active_page, video.text_rows, video.text_cols);
 #endif
 
   // Need to wrap around and start over, but also the video mode could have
   // changed since our last cycle, and the screne is now SHORTER than it used
   // to be.
-  if (vga_next_row >= vga.text_rows) {
-    vga_next_row = 0;
+  if (video_next_row >= video.text_rows) {
+    video_next_row = 0;
   }
+  
+  // We are at the begining?
+  if (video_next_row == 0) {
+    // Check if screen has been updated
+    video_curr_chksum = video_checksum_frame_buffer(0, video.text_rows * video.text_cols * VIDEO_WORD);    
+    if (video_curr_chksum == video_chksum) {
+      // No changes to the video frame buffer.  Don't send anything.
+      return;
+    } else {
+      // Go ahead
+      video_chksum = video_curr_chksum;      
+    }
+  }
+
 
   // Compute how many rows we can fit into an Ethernet frame given the current
   // row width.
   rows = (ETH_FRAME_LEN -
           (sizeof(struct ether_header) + sizeof(struct ProtocolHeader) +
-           sizeof(struct VgaText))) /
-         (vga.text_cols * VGA_WORD);
+           sizeof(struct VideoText))) /
+         (video.text_cols * VIDEO_WORD);
 #if DEBUG
-  vga_printf(40, 21, 15, "rows: %d %d %d    ;", rows, vga_next_row,
-             vga.text_rows);
+  video_printf(40, 21, 15, "rows: %d %d %d    ;", rows, video_next_row,
+             video.text_rows);
 #endif
 
   // Reduce rows if we're near the end of the current frame buffer.
-  if (rows + vga_next_row > vga.text_rows) {
-    rows = vga.text_rows - vga_next_row;
+  if (rows + video_next_row > video.text_rows) {
+    rows = video.text_rows - video_next_row;
   }
 
 #if DEBUG
-  vga_printf(40, 22, 11, "rows: %d    ;", rows);
+  video_printf(40, 22, 11, "rows: %d    ;", rows);
 #endif
+ 
 
   // How many words to copy, and from where?
-  offset = vga_next_row * vga.text_cols * VGA_WORD;
-  word_count = rows * vga.text_cols;
-  payload_len = sizeof(struct VgaText) + (word_count * VGA_WORD);
+  offset = video_next_row * video.text_cols * VIDEO_WORD;
+  word_count = rows * video.text_cols;
+  payload_len = sizeof(struct VideoText) + (word_count * VIDEO_WORD);
 
   // Advance to the next starting row for the next cycle.
-  vga_next_row += rows;
+  video_next_row += rows;
 
 #if DEBUG
-  vga_printf(40, 23, 12, "of:%04x wc:%04x pl:%04x", offset, word_count,
+  video_printf(40, 23, 12, "of:%04x wc:%04x pl:%04x", offset, word_count,
              payload_len);
 #endif
 
@@ -170,27 +191,26 @@ void session_mgr_update_all() {
   out_ph->payload_len = htons(payload_len);
   out_ph->pkt_type = htons(V1_VGA_TEXT);
 
-  resp->text_rows = vga.text_rows;
-  resp->text_cols = vga.text_cols;
-  resp->cursor_row = vga.cursor_row;
-  resp->cursor_col = vga.cursor_col;
+  resp->text_rows = video.text_rows;
+  resp->text_cols = video.text_cols;
+  resp->cursor_row = video.cursor_row;
+  resp->cursor_col = video.cursor_col;
   resp->offset = htons(offset);
-  resp->count = htons(word_count * VGA_WORD);
+  resp->count = htons(word_count * VIDEO_WORD);
 
 #if DEBUG
-  vga_printf(40, 24, 13, "%04x %04x %04x %d  ;", (uint16_t)vga_data,
+  video_printf(40, 24, 13, "%04x %04x %04x %d  ;", (uint16_t)video_data,
              (uint16_t)g_sessions, (uint16_t)g_session_eof, active_sessions);
 #endif
 
-  vga_copy_from_frame_buffer(vga_data, offset, word_count);
-  // memset(vga_data, 0x1f, word_count * 2);
-
+  video_copy_from_frame_buffer(video_data, offset, word_count);
+  // memset(video_data, 0x1f, word_count * 2);
+    
   for (s = g_sessions; s < g_session_eof; ++s) {
     // Is session in use?
     if (!memcmp(s->mac_addr, null_if_addr, ETH_ALEN)) {
       continue;
     }
-
     memcpy(out_eh->dest_mac_addr, s->mac_addr, ETH_ALEN);
     out_ph->session_id = htonl(s->session_id);
     pktdrv_send(g_send_buffer, COMBINED_HEADER_LEN + payload_len);

--- a/src/server/session.h
+++ b/src/server/session.h
@@ -21,6 +21,9 @@ struct Session {
 
   // MAC address of the client.
   uint8_t mac_addr[ETH_ALEN];
+
+  // Checksum of the video data that we sent to this client.
+  uint16_t video_chksum;
 };
 
 extern void session_mgr_init();

--- a/src/server/video.h
+++ b/src/server/video.h
@@ -1,0 +1,18 @@
+#include "../lib16/video.h"
+#include "server/globals.h"
+
+
+#define video_write_str(x, y, attr, str) \
+    video_write_str(video_segment, x, y, attr, str)
+
+#define video_copy_from_frame_buffer(dest, offset, words) \
+    video_copy_from_frame_buffer(video_segment, dest, offset, words)
+
+#define video_clear_rows(y1, y2) \
+    video_clear_rows(video_segment, y1, y2)
+
+#define video_printf(x, y, attr, fmt, ...)  \
+     video_printf(video_segment, x, y, attr, fmt, __VA_ARGS__)
+
+#define VIDEO_WORD (video_segment == 0xB800 ? 2 : 1)
+


### PR DESCRIPTION
This commit replaces the previous `vga` subsystem with a new, more agnostic `video` subsystem designed to work across multiple legacy display adapters including VGA, EGA, CGA, and MDA.

Key changes:
- Abstracted video functions into a common `video` module.
- Added support for detecting and interacting with VGA, EGA, CGA, and MDA.
- Introduced a `_video_checksum_frame_buffer` mechanism to efficiently
  calculate a checksum of the video memory.

Performance Improvement:
- By comparing checksums, video screen updates are now only transmitted over the network when actual changes have occurred. This significantly  reduces CPU load and network bandwidth consumption compared to  unconditional updates.

Testing:
- Core video subsystem functionality verified on real hardware with CGA.
- Tested successfully in QEMU using VGA emulation. 
- Video routines confirmed working on MDA hardware, although the full  `rmtdos` TSR application currently faces unrelated issues on the  8086 test machine with MDA. (Working on it)